### PR TITLE
Improvement of the first version of the template

### DIFF
--- a/0000-template.md
+++ b/0000-template.md
@@ -31,7 +31,7 @@ Explain the proposal as if it was already included in the language, or in the ke
 - Explaining how CC+ programmers should *think* about the feature and how it should impact on the way they use it. The impact should be explained in as concrete a way as possible.
 - Explaining how the feature of the language or the kernel fits into use and the relationship between its different parts.
 - If applicable, provide examples of error messages, depreciation warnings or migration advice.
-- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers. To clarify: the existing programmer will    have to learn a new feature every time there is one.  Whereas the new programmer will learn with the existing features and those added before he arrived in the project. Also, the existing programmer can serve as a referent when the new programmer experiences difficulty with the task.
+- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers. To clarify: You need to **explain** how developers feel about this feature depending on their experience about the project.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation

--- a/0000-template.md
+++ b/0000-template.md
@@ -29,9 +29,9 @@ Explain the proposal as if it was already included in the language, or in the ke
 - Introducing new named concepts.
 - Explaining the functionality largely through examples.
 - Explaining how CC+ programmers should *think* about the feature and how it should impact on the way they use it. The impact should be explained in as concrete a way as possible.
-- Explaining how the feature fits into use and the relationship between its different parts.
+- Explaining how the feature of the language or the kernel fits into use and the relationship between its different parts.
 - If applicable, provide examples of error messages, depreciation warnings or migration advice.
-- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers.
+- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers. To clarify: the existing programmer will    have to learn a new feature every time there is one.  Whereas the new programmer will learn with the existing features and those added before he arrived in the project. Also, the existing programmer can serve as a referent when the new programmer experiences difficulty with the task.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -96,7 +96,7 @@ RFC you are writing but otherwise related.
 If you have tried and cannot think of any future possibilities,
 you may simply state that you cannot think of anything.
 
-Note that having something written down in the future-possibilities section
+Note that having something written down in the future possibilities section
 is not a reason to accept the current or a future RFC; such notes should be
 in the section on motivation or rationale in this or subsequent RFCs.
 The section merely provides additional information.

--- a/0000-template.md
+++ b/0000-template.md
@@ -21,18 +21,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-#Guide-level-explanation
+# Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it were already included in the language, or in the kernel, and you were teaching it to another CC+ programmer or Cpcdos OS2.2 contributor. This usually means :
+Explain the proposal as if it was already included in the language, or in the kernel, and you was teaching it to another CC+ programmer or Cpcdos OS2.2 contributor. This usually means :
 
 - Introducing new named concepts.
 - Explaining the functionality largely through examples.
 - Explaining how CC+ programmers should *think* about the feature and how it should impact on the way they use it. The impact should be explained in as concrete a way as possible.
-- Explain how the feature fits into the kernel and its relationship to different parts of it.
+- Explaining how the feature fits into use and the relationship between its different parts.
 - If applicable, provide examples of error messages, depreciation warnings or migration advice.
-- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers. The same applies to features to be added to the kernel.
-
+- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers.
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -57,17 +56,16 @@ Why should we *not* do this?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
 
-#prior art
+# Prior art
 [prior-art]: #prior-art
 
-Discuss prior art, the good and the bad, in relation to this proposal.
-Here are some examples of what this might include:
+Discuss prior art, both the good and the bad, in relation to this proposal.
+A few examples of what this can include are:
 
-- For language, library, cargo, tool and compiler proposals: Does this feature exist in other programming languages and what has been the experience of their community?
-- For kernel proposals: Does this functionality exist in other kernels and what has been the experience of their community?
+- For language proposals: Does this feature exist in other programming languages and what has been the experience of their community?
 - For community proposals: Does this functionality exist in other communities and what has been their experience with it?
 - For other teams: What lessons can we learn from what other communities have done here?
-- Documents: Are there any published articles or interesting papers that deal with this topic? If you have relevant articles to refer to, they can serve as a more detailed theoretical basis.
+- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
 
 This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
 If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
@@ -82,20 +80,23 @@ Please also take into consideration that rust sometimes intentionally diverges f
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-#Future possibilities
+# Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would be
-and how this would affect the project as a whole, in a holistic way.
-Try to use this section as a tool to consider more fully all possible interactions with the project.
-Also consider how this fits into the roadmap of the project and the sub-team concerned.
+Think about what the natural extension and evolution of your proposal would
+be and how it would affect the language and project as a whole in a holistic
+way. Try to use this section as a tool to more fully consider all possible
+interactions with the project and language in your proposal.
+Also consider how this all fits into the roadmap for the project
+and of the relevant sub-team.
 
-This is also a good place to 'throw out ideas', if they are out of scope for the RFC you are writing, but otherwise related.
+This is also a good place to "dump ideas", if they are out of scope for the
+RFC you are writing but otherwise related.
 
-If you have tried and can't think of any other possibilities,
-you can simply state that you can't think of anything.
+If you have tried and cannot think of any future possibilities,
+you may simply state that you cannot think of anything.
 
-Note that having something written in the future possibilities section
-is not a reason to accept the current or a future RFC; such notes should be in the
-in the motivation or rationale section of this or subsequent RFCs.
-This section simply provides additional information.
+Note that having something written down in the future-possibilities section
+is not a reason to accept the current or a future RFC; such notes should be
+in the section on motivation or rationale in this or subsequent RFCs.
+The section merely provides additional information.

--- a/0000-template.md
+++ b/0000-template.md
@@ -1,7 +1,7 @@
 # Title-cased Name of the Feature
 
 - Status: proposed ("proposed", "agreed", "active", "implemented" or "rejected")
-- Related to: (fill me with either "OS" or "CpcdosC+")
+- Related to: (fill me with either "Kernel" or "CpcdosC+")
 - Start Date: (fill me in with today's date, YYYY-MM-DD)
 - Supersedes: (fill me in with a link to RFC this supersedes - if applicable)
 - Superseded by: (fill me in with a link to RFC this is superseded by - if applicable)
@@ -21,16 +21,18 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Why are we doing this? What use cases does it support? What is the expected outcome?
 
-# Guide-level explanation
+#Guide-level-explanation
 [guide-level-explanation]: #guide-level-explanation
 
-Explain the proposal as if it was already included in the language and you were teaching it to another CC+ programmer. That generally means:
+Explain the proposal as if it were already included in the language, or in the kernel, and you were teaching it to another CC+ programmer or Cpcdos OS2.2 contributor. This usually means :
 
 - Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how CC+ programmers should *think* about the feature, and how it should impact the way they use Rust. It should explain the impact as concretely as possible.
-- If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-- If applicable, describe the differences between teaching this to existing CC+ programmers and new Rust programmers.
+- Explaining the functionality largely through examples.
+- Explaining how CC+ programmers should *think* about the feature and how it should impact on the way they use it. The impact should be explained in as concrete a way as possible.
+- Explain how the feature fits into the kernel and its relationship to different parts of it.
+- If applicable, provide examples of error messages, depreciation warnings or migration advice.
+- If applicable, describe the differences between teaching this functionality to existing CC+ programmers and to new CC+ programmers. The same applies to features to be added to the kernel.
+
 
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
@@ -55,16 +57,17 @@ Why should we *not* do this?
 - What other designs have been considered and what is the rationale for not choosing them?
 - What is the impact of not doing this?
 
-# Prior art
+#prior art
 [prior-art]: #prior-art
 
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
+Discuss prior art, the good and the bad, in relation to this proposal.
+Here are some examples of what this might include:
 
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
+- For language, library, cargo, tool and compiler proposals: Does this feature exist in other programming languages and what has been the experience of their community?
+- For kernel proposals: Does this functionality exist in other kernels and what has been the experience of their community?
+- For community proposals: Does this functionality exist in other communities and what has been their experience with it?
 - For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
+- Documents: Are there any published articles or interesting papers that deal with this topic? If you have relevant articles to refer to, they can serve as a more detailed theoretical basis.
 
 This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
 If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
@@ -79,23 +82,20 @@ Please also take into consideration that rust sometimes intentionally diverges f
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
 - What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
 
-# Future possibilities
+#Future possibilities
 [future-possibilities]: #future-possibilities
 
-Think about what the natural extension and evolution of your proposal would
-be and how it would affect the language and project as a whole in a holistic
-way. Try to use this section as a tool to more fully consider all possible
-interactions with the project and language in your proposal.
-Also consider how this all fits into the roadmap for the project
-and of the relevant sub-team.
+Think about what the natural extension and evolution of your proposal would be
+and how this would affect the project as a whole, in a holistic way.
+Try to use this section as a tool to consider more fully all possible interactions with the project.
+Also consider how this fits into the roadmap of the project and the sub-team concerned.
 
-This is also a good place to "dump ideas", if they are out of scope for the
-RFC you are writing but otherwise related.
+This is also a good place to 'throw out ideas', if they are out of scope for the RFC you are writing, but otherwise related.
 
-If you have tried and cannot think of any future possibilities,
-you may simply state that you cannot think of anything.
+If you have tried and can't think of any other possibilities,
+you can simply state that you can't think of anything.
 
-Note that having something written down in the future-possibilities section
-is not a reason to accept the current or a future RFC; such notes should be
-in the section on motivation or rationale in this or subsequent RFCs.
-The section merely provides additional information.
+Note that having something written in the future possibilities section
+is not a reason to accept the current or a future RFC; such notes should be in the
+in the motivation or rationale section of this or subsequent RFCs.
+This section simply provides additional information.


### PR DESCRIPTION
I just reworked some parts of the template to make it clearer to Cpcdos.

**In particular :**

- The term "OS" replaced by "Kernel" since it is a kernel project and not an OS directly (yeah I know, it's a bit of a pain in the ass but words have meanings).

- Added some missing parts about the Cpcdos kernel.

- Removal of the word "Rust" because it doesn't look very professional to keep this in an RFC that has nothing to do with Rust (and if it can avoid a new language war within the community, it's already a good thing).

**Any criticism is welcome. If there are aspects of my Pull Request that you would like to see refined, we will do so.**